### PR TITLE
Fix polymer_ui_clock month off-by-one error

### DIFF
--- a/lib/polymer_ui_clock/polymer_ui_clock.dart
+++ b/lib/polymer_ui_clock/polymer_ui_clock.dart
@@ -94,7 +94,7 @@ class PolymerUiClock extends PolymerElement {
   }
 
   void timeChanged() {
-    dateStr = [_days[time.weekday - 1], _months[time.month], time.day].join(' ');
+    dateStr = [_days[time.weekday - 1], _months[time.month - 1], time.day].join(' ');
     hours = time.hour;
     minutes = time.minute;
     seconds = time.second;


### PR DESCRIPTION
Months in Dart's DateTime are one-based, but zero-based was assumed (#163)
